### PR TITLE
ENH: do not spawn any server when 'streaming_servers' is not configured

### DIFF
--- a/dug_seis/acquisition/streaming.py
+++ b/dug_seis/acquisition/streaming.py
@@ -369,8 +369,10 @@ class Streamer():
 def create_servers(param):
     sampling_rate = param['Acquisition']['hardware_settings']['sampling_frequency']
     streamers = []
+    if 'streaming_servers' not in param['Acquisition']:
+        return streamers
     for server in param['Acquisition']['streaming_servers']:
-        print(f"server {server}")
+        logger.info(f"Starting server: {server}")
         channels = []
         for ch_id in server['channels']:
             if str(ch_id).isdigit():


### PR DESCRIPTION
This is now optional

  streaming_servers:
    -   host                  : "" # emtpy means all interfaces/ip addresses
        port                  : 65535
        channels              : [1-32]